### PR TITLE
👻 add empty workspace members array

### DIFF
--- a/validate-witx/Cargo.toml
+++ b/validate-witx/Cargo.toml
@@ -5,6 +5,9 @@ version = "0.1.0"
 authors = ["Fastly <oss@fastly.com>"]
 edition = "2018"
 
+[workspace]
+members = []
+
 [dependencies]
 anyhow = "^1.0.40"
 witx = "^0.9.1"


### PR DESCRIPTION
This odd little commit is a workaround for a Cargo workspaces bug,
described in rust-lang/cargo#6745; this workaround is described in a
comment there[1].

When using this repository as a submodule, it becomes impossible to
validate the definitions with the command below, if it contains a Cargo
workspace:

```
cargo run --manifest-path=validate-witx/Cargo.toml ./compute-at-edge.witx
```

Moreover, we cannot always add the repo to the `exclude` array, for
reasons explained in the attached Cargo issue.

So, we'll introduce this empty workspace array, to avoid that issue for
now.

[1]: https://github.com/rust-lang/cargo/issues/6745#issuecomment-472667516