### PR TITLE
Add close definitions for Response/Request handles

### DIFF
--- a/compute-at-edge.witx
+++ b/compute-at-edge.witx
@@ -292,6 +292,11 @@
                 (error $fastly_status))
         )
     )
+
+    (@interface func(export "close")
+        (param $h $request_handle)
+        (result $err (expected (error $fastly_status)))
+    )
 )
 
 (module $fastly_http_resp
@@ -386,6 +391,11 @@
     (@interface func (export "status_set")
         (param $h $response_handle)
         (param $status $http_status)
+        (result $err (expected (error $fastly_status)))
+    )
+
+    (@interface func(export "close")
+        (param $h $response_handle)
         (result $err (expected (error $fastly_status)))
     )
 )


### PR DESCRIPTION
This commit takes the changes from the internal repo and exposes them
ahead of our new SDK release so that we can also update viceroy before
then to be able to also handle the fact that handles have a new drop
implementation for the Rust SDK that will automatically close themselves
out when they go out of scope. If people use Viceroy with the new SDK
version, then their programs will constantly crash and we can't have
that happen.