### PR TITLE
Add auto_decompress_response_set host call

### DIFF
--- a/compute-at-edge.witx
+++ b/compute-at-edge.witx
@@ -297,6 +297,12 @@
         (param $h $request_handle)
         (result $err (expected (error $fastly_status)))
     )
+
+    (@interface func (export "auto_decompress_response_set")
+        (param $h $request_handle)
+        (param $encodings $content_encodings)
+        (result $err (expected (error $fastly_status)))
+    )
 )
 
 (module $fastly_http_resp

--- a/typenames.witx
+++ b/typenames.witx
@@ -110,3 +110,6 @@
 (typename $is_done u32)
 (typename $done_idx u32)
 
+(typename $content_encodings
+    (flags (@witx repr u32)
+        $gzip))


### PR DESCRIPTION
With the newest 0.8.1 SDK release we need to move the host call to the
public repo so that we can update Viceroy and fix
https://github.com/fastly/Viceroy/issues/110. We just need to stub out
the hostcall there, but it depends on this repo to have the latest
definitions. This commit promotes the hostcall from an internal one to
an external.